### PR TITLE
ユーザー新規登録、snsログイン

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,5 +1,30 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
+  # callback for facebook
+  def facebook
+    callback_for(:facebook)
+  end
   
+  # callback for google
+  def google_oauth2
+    callback_for(:google)
+  end
+
+  # common callback method
+  def callback_for(provider)
+    @user = User.from_omniauth(request.env["omniauth.auth"])
+    if @user.persisted?
+      sign_in_and_redirect @user, event: :authentication #this will throw if @user is not activated
+      set_flash_message(:notice, :success, kind: "#{provider}".capitalize) if is_navigational_format?
+    else
+      session["devise.#{provider}_data"] = request.env["omniauth.auth"].except("extra")
+      redirect_to new_user_registration_url
+    end
+  end
+
+  def failure
+    redirect_to root_path
+  end
 
 end
+

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,5 +9,11 @@ class User < ApplicationRecord
 
   devise :omniauthable, omniauth_providers: %i[facebook google_oauth2]
   # omniauthのコールバック時に呼ばれるメソッド
-  
+  def self.from_omniauth(auth)
+    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
+      user.email = auth.info.email
+      user.password = Devise.friendly_token[0,20]
+    end
+  end
 end
+

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -296,5 +296,7 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
-  
+  config.omniauth :facebook, ENV['FACEBOOK_KEY'], ENV['FACEBOOK_SECRET']
+  config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET']
+  OmniAuth.config.logger = Rails.logger if Rails.env.development?
 end


### PR DESCRIPTION
# What
ユーザーの新規登録を行えるようにする
snsアカウントを使ったログインをできるようにする

# why
メルカリ同様の機能をつけるため